### PR TITLE
SC/VLE: VR Java - Disappear Pause/Play icon when double click on List…

### DIFF
--- a/src/uk/ac/open/audio/streaming/PlayerProgress.java
+++ b/src/uk/ac/open/audio/streaming/PlayerProgress.java
@@ -578,7 +578,7 @@ public class PlayerProgress extends JComponent
 		buffer.drawImage(fancy2,0,0,null);
 		g2.drawImage(fancy,0,0, null);
 
-		if(barOpacity!=0 || currentState==State.RECORDING)
+		if(currentState==State.RECORDING || currentState==State.PLAYING)
 		{
 			if (this.playPauseImage != null)
 			{


### PR DESCRIPTION
…en/Stop button below VR box: #265740
 Pause/Play icon disappears on multiple click on Listen/Stop button below VR box